### PR TITLE
Removed references to SPH, as it is no longer a part of GameScenes.

### DIFF
--- a/TestButtons/TestButtons.cs
+++ b/TestButtons/TestButtons.cs
@@ -69,7 +69,7 @@ class TestButtons : MonoBehaviour {
 		button6 = ToolbarManager.Instance.add("test", "button6");
 		button6.TexturePath = "000_Toolbar/img_buttonTypeMNode";
 		button6.ToolTip = "Button Visible Only in Editors";
-		button6.Visibility = new GameScenesVisibility(GameScenes.EDITOR, GameScenes.SPH);
+		button6.Visibility = new GameScenesVisibility(GameScenes.EDITOR);
 		button6.OnClick += (e) => Debug.Log("button6 clicked");
 
 		// button that is only visible in the flight scene and flight map

--- a/Toolbar/API/GameScenesVisibility.cs
+++ b/Toolbar/API/GameScenesVisibility.cs
@@ -35,7 +35,7 @@ namespace Toolbar {
 	/// <example>
 	/// <code>
 	/// IButton button = ...
-	/// button.Visibility = new GameScenesVisibility(GameScenes.EDITOR, GameScenes.SPH);
+	/// button.Visibility = new GameScenesVisibility(GameScenes.EDITOR);
 	/// </code>
 	/// </example>
 	/// <seealso cref="IButton.Visibility"/>

--- a/Toolbar/Internal/Toolbar/ToolbarGameScene.cs
+++ b/Toolbar/Internal/Toolbar/ToolbarGameScene.cs
@@ -39,7 +39,6 @@ namespace Toolbar {
 		EDITOR,
 		FLIGHT,
 		TRACKSTATION,
-		SPH,
 		PSYSTEM,
 
 		FLIGHTMAP
@@ -67,8 +66,6 @@ namespace Toolbar {
 					return MapView.MapIsEnabled ? ToolbarGameScene.FLIGHTMAP : ToolbarGameScene.FLIGHT;
 				case GameScenes.TRACKSTATION:
 					return ToolbarGameScene.TRACKSTATION;
-				case GameScenes.SPH:
-					return ToolbarGameScene.SPH;
 				case GameScenes.PSYSTEM:
 					return ToolbarGameScene.PSYSTEM;
 

--- a/Wrapper/ToolbarWrapper.cs
+++ b/Wrapper/ToolbarWrapper.cs
@@ -402,7 +402,7 @@ namespace ToolbarWrapper {
 	/// <example>
 	/// <code>
 	/// IButton button = ...
-	/// button.Visibility = new GameScenesVisibility(GameScenes.EDITOR, GameScenes.SPH);
+	/// button.Visibility = new GameScenesVisibility(GameScenes.EDITOR);
 	/// </code>
 	/// </example>
 	/// <seealso cref="IButton.Visibility"/>


### PR DESCRIPTION
GameScenes.SPH is no longer a part of the KSP API; this commit removes it throughout Toolbar and provides at least nominal 0.90.0 compatibility.
