### PR TITLE
catch InvalidOperationException from ToolbarWrapper

### DIFF
--- a/Wrapper/ToolbarWrapper.cs
+++ b/Wrapper/ToolbarWrapper.cs
@@ -726,9 +726,16 @@ namespace ToolbarWrapper {
 		}
 
 		internal static Type getType(string name) {
-			return AssemblyLoader.loadedAssemblies
-				.SelectMany(a => a.assembly.GetExportedTypes())
-				.SingleOrDefault(t => t.FullName == name);
+			foreach (AssemblyLoader.LoadedAssembly assembly in AssemblyLoader.loadedAssemblies) {
+				try {
+					var type = assembly.assembly.GetExportedTypes().SingleOrDefault(t => t.FullName == name);
+					if (type != null)
+						return type;
+				}
+				catch (InvalidOperationException) {
+				}
+			}
+			return null;
 		}
 
 		internal static PropertyInfo getProperty(Type type, string name) {


### PR DESCRIPTION
https://github.com/KSP-KOS/KOS/pull/1690
https://github.com/MuMech/MechJeb2/issues/723

Catch InvalidOperationException from `ToolbarTypes.getType()`, to prevent plugin crash caused by an incompatible plugin. I found the fix from https://github.com/MuMech/MechJeb2/commit/b966a87399b7b31ed177465b347d09fe4ae14019

For example, https://github.com/bssthu/SteamGauges-Fork/releases/tag/v1.7.2u2 would crash plugins using ToolbarWrapper, but the mod itself is working.