### PR TITLE
Prevent version check warning on startup with game version 1.1.3

### DIFF
--- a/Toolbar/etc/Toolbar.version
+++ b/Toolbar/etc/Toolbar.version
@@ -23,7 +23,7 @@
 	"KSP_VERSION_MAX": {
 		"MAJOR": 1,
 		"MINOR": 1,
-		"PATCH": 2,
+		"PATCH": 3,
 		"BUILD": 0
 	}
 }


### PR DESCRIPTION
As of patch 1.1.3, an AVC dialog pops up on game startup that says "Unsupported version... use 1.1.2" - which is expected since the last release was before 1.1.3. I just bumped the max version as I have been using Toolbar with 1.1.3 and haven't seen any exceptions thrown or functionality missing. Apologies if this is an unwanted request.