### PR TITLE
Don't try to get exported types from dynamic modules

### DIFF
--- a/Wrapper/ToolbarWrapper.cs
+++ b/Wrapper/ToolbarWrapper.cs
@@ -726,13 +726,18 @@ namespace ToolbarWrapper {
 		}
 
 		internal static Type getType(string name) {
-		        AssemblyLoader.loadedAssemblies.TypeOperation(t =>
-		        {
-		            if (t.FullName == name)
-		                return t;
-		        });
-		        
-		        throw new ArgumentException(string.Format("Couldn't find type '{0}'!", name);
+			Type type = null;
+			AssemblyLoader.loadedAssemblies.TypeOperation(t =>
+			{
+				if (t.FullName == name)
+					type = t;
+			});
+			
+			if (type != null)
+			{
+				return type;
+			}
+			throw new ArgumentException(string.Format("Couldn't find type '{0}'!", name));
 		}
 
 		internal static PropertyInfo getProperty(Type type, string name) {

--- a/Wrapper/ToolbarWrapper.cs
+++ b/Wrapper/ToolbarWrapper.cs
@@ -727,6 +727,7 @@ namespace ToolbarWrapper {
 
 		internal static Type getType(string name) {
 			return AssemblyLoader.loadedAssemblies
+				.Where(a => !a.assembly.IsDynamic)
 				.SelectMany(a => a.assembly.GetExportedTypes())
 				.SingleOrDefault(t => t.FullName == name);
 		}

--- a/Wrapper/ToolbarWrapper.cs
+++ b/Wrapper/ToolbarWrapper.cs
@@ -733,11 +733,7 @@ namespace ToolbarWrapper {
 					type = t;
 			});
 			
-			if (type != null)
-			{
-				return type;
-			}
-			return null;
+			return type;
 		}
 
 		internal static PropertyInfo getProperty(Type type, string name) {

--- a/Wrapper/ToolbarWrapper.cs
+++ b/Wrapper/ToolbarWrapper.cs
@@ -737,7 +737,7 @@ namespace ToolbarWrapper {
 			{
 				return type;
 			}
-			throw new ArgumentException(string.Format("Couldn't find type '{0}'!", name));
+			return null;
 		}
 
 		internal static PropertyInfo getProperty(Type type, string name) {

--- a/Wrapper/ToolbarWrapper.cs
+++ b/Wrapper/ToolbarWrapper.cs
@@ -726,10 +726,13 @@ namespace ToolbarWrapper {
 		}
 
 		internal static Type getType(string name) {
-			return AssemblyLoader.loadedAssemblies
-				.Where(a => !a.assembly.IsDynamic)
-				.SelectMany(a => a.assembly.GetExportedTypes())
-				.SingleOrDefault(t => t.FullName == name);
+		        AssemblyLoader.loadedAssemblies.TypeOperation(t =>
+		        {
+		            if (t.FullName == name)
+		                return t;
+		        });
+		        
+		        throw new ArgumentException(string.Format("Couldn't find type '{0}'!", name);
 		}
 
 		internal static PropertyInfo getProperty(Type type, string name) {


### PR DESCRIPTION
Right, so Contract Configurator is set to break the toolbar wrapper code in 1.2. 😢, due to some nasty Reflection.Emit code that I added to it to do some stuff a bit more dynamically.

I don't really have a good answer to the problem other than sending you a PR and dealing with the fallout of every mod having to update the wrapper code.

Sorry!
